### PR TITLE
Add verified permissions for access key types

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -28,19 +28,54 @@ The first time you start PR Focus, you'll be asked to provide some setup details
 
 ### Generate a GitHub Access Token
 
-For details about generating a GitHub access token, refer to the GitHub Authentication documentation page [Manage Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
+PR Focus requires a GitHub access token with permissions to access the repositories you want to watch.
 
-*Note: The permissions below assume you are using a Classic API key. PR Focus has not yet been tested with a fine-grained API access key. I'll provide details soon about what permissions are needed for a fine-grained access token. Meanwhile, please use a Classic API key with PR Focus during beta testing.*
+For details about how to generate a GitHub access token, refer to the GitHub Authentication documentation page [Manage Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 
-The access token you generate should have `repo` read permissions for any repository you want to watch in PR Focus. PR Focus also needs `user` read permissions to get your username and avatar for use in the app.
+GitHub provides two types of access tokens:
+
+- A fine-grained access token (currently in beta) which provides more precise control over what the bearer can access
+- A classic access token with less precise control over what the bearer can access
+
+The required permissions for PR Focus to fetch pull request data vary depending on which type of access token you create. If you are not seeing pull requests after adding a repository to PR Focus, verify that your API access token has the appropriate permissions for the repository.
+
+#### Fine-Grained Access Token Permissions
+
+GitHub's fine-grained access token provides the most precise control over what a user can access. As a result, PR Focus needs a number of permissions to get all the data it needs. PR Focus requires:
+
+Repository permissions
+- Actions: Read-only
+- Commit statuses: Read-only
+- Contents: Read-only
+- Deployments: Read-only
+- Issues: Read-only
+- Metadata: Read-only
+- Pull-Requests: Read-only
+- Workflows: Read and write (PR Focus does not need write permission, but GitHub does not provide read-only access for Workflows, so Read and write is the only option)
+
+Account permissions
+- Profile: Read and write (PR Focus does not need write permission, but GitHub does not provide read-only access for the user Profile, so Read and write is the only option)
+
+#### Classic Access Token Permissions
+
+If you're using a Classic access token, it must have the following permissions:
+
+- `repo` read permissions for any repository you want to watch in PR Focus. 
+- `user` read permissions to get your username and avatar for use in the app.
 
 If your organization uses SAML single sign-on (SSO), and you use a classic personal access token, you must configure SSO for your personal access token after you create it. For more details, refer to the GitHub Authentication documentation page [Authorizing a personal access token for use with SAML single sign-on](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
 
-When you enter the access token, PR Focus saves it securely to your [macOS Apple Keychain](https://support.apple.com/guide/mac-help/use-keychains-to-store-passwords-mchlf375f392/mac). PR Focus does not store your access token directly or otherwise transmit it except to make API calls to GitHub. If you ever want to remove your access token from Keychain, you can find it in the Keychain Access app. 
+#### How does PR Focus store and transmit the access token?
+
+When you enter the access token, PR Focus saves it securely to your [macOS Apple Keychain](https://support.apple.com/guide/mac-help/use-keychains-to-store-passwords-mchlf375f392/mac). PR Focus does not store your access token directly in the app code or otherwise transmit it except to make API calls to GitHub. If you ever want to remove your access token from Keychain, you can find it in the Keychain Access app. 
 
 Note that if you remove your access token from Keychain, PR Focus can no longer make API calls to GitHub. This means PR Focus will no longer be able to fetch PR updates or new PRs.
 
+#### Updating the access token
+
 You can update your access token later from the PR Focus **Global Settings**.
+
+#### Why does PR Focus need user read permissions?
 
 When you provide an access token during setup, if your access token has the appropriate permissions, PR Focus uses it to create a User Profile in the app for you. It reads your GitHub username and avatar and displays it in the **Global Settings** in the app. PR Focus uses this information to determine whether a PR was made by you, and whether you are a reviewer or assigned to a PR.
 

--- a/content/en/docs/settings/_index.md
+++ b/content/en/docs/settings/_index.md
@@ -21,15 +21,50 @@ Press the **Edit API Key** button to provide a new API access token.
 
 For details about generating a GitHub access token, refer to the GitHub Authentication documentation page [Manage Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 
-The access token you generate should have `repo` read permissions for any repository you want to watch in PR Focus. PR Focus also needs `user` read permissions to get your username and avatar for use in the app.
+GitHub provides two types of access tokens:
+
+- A fine-grained access token (currently in beta) which provides more precise control over what the bearer can access
+- A classic access token with less precise control over what the bearer can access
+
+The required permissions for PR Focus to fetch pull request data vary depending on which type of access token you create. If you are not seeing pull requests after adding a repository to PR Focus, verify that your API access token has the appropriate permissions for the repository.
+
+### Fine-Grained Access Token Permissions
+
+GitHub's fine-grained access token provides the most precise control over what a user can access. As a result, PR Focus needs a number of permissions to get all the data it needs. PR Focus requires:
+
+Repository permissions
+- Actions: Read-only
+- Commit statuses: Read-only
+- Contents: Read-only
+- Deployments: Read-only
+- Issues: Read-only
+- Metadata: Read-only
+- Pull-Requests: Read-only
+- Workflows: Read and write (PR Focus does not need write permission, but GitHub does not provide read-only access for Workflows, so Read and write is the only option)
+
+Account permissions
+- Profile: Read and write (PR Focus does not need write permission, but GitHub does not provide read-only access for the user Profile, so Read and write is the only option)
+
+### Classic Access Token Permissions
+
+If you're using a Classic access token, it must have the following permissions:
+
+- `repo` read permissions for any repository you want to watch in PR Focus. 
+- `user` read permissions to get your username and avatar for use in the app.
 
 If your organization uses SAML single sign-on (SSO), and you use a classic personal access token, you must configure SSO for your personal access token after you create it. For more details, refer to the GitHub Authentication documentation page [Authorizing a personal access token for use with SAML single sign-on](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
 
-When you enter the access token, PR Focus saves it securely to your [macOS Apple Keychain](https://support.apple.com/guide/mac-help/use-keychains-to-store-passwords-mchlf375f392/mac). PR Focus does not store your access token directly or otherwise transmit it except to make API calls to GitHub. If you ever want to remove your access token from Keychain, you can find it in the Keychain Access app. 
+#### How does PR Focus store and transmit the access token?
 
-## Profile URL
+When you enter the access token, PR Focus saves it securely to your [macOS Apple Keychain](https://support.apple.com/guide/mac-help/use-keychains-to-store-passwords-mchlf375f392/mac). PR Focus does not store your access token directly in the app code or otherwise transmit it except to make API calls to GitHub. If you ever want to remove your access token from Keychain, you can find it in the Keychain Access app. 
 
-You can change the GitHub profile that PR Focus uses to determine whether you are the assignee/reviewer/person making the pull request. Provide a new GitHub profile URL in the format `https://github.com/YOUR-USERNAME-HERE` and replace `YOUR-USERNAME-HERE` with the new GitHub username you'd like to use.
+Note that if you remove your access token from Keychain, PR Focus can no longer make API calls to GitHub. This means PR Focus will no longer be able to fetch PR updates or new PRs.
+
+#### Why does PR Focus need user read permissions?
+
+When you provide an access token during setup, if your access token has the appropriate permissions, PR Focus uses it to create a User Profile in the app for you. It reads your GitHub username and avatar and displays it in the **Global Settings** in the app. PR Focus uses this information to determine whether a PR was made by you, and whether you are a reviewer or assigned to a PR.
+
+If your access token doesn't have the appropriate permissions, PR Focus can't fetch your user profile and can't proceed with the initial user setup.
 
 PR Focus does not currently support having multiple GitHub user profiles. If this is something you need, please file a feature request.
 


### PR DESCRIPTION
A beta tester reported problems using a fine-grained access token with PR Focus in Issue https://github.com/dacharyc/prfocus-website/issues/7

After consulting the GitHub documentation, I was able to verify the required permissions for the data that PR Focus needs to access. I have manually tested these permissions with multiple repositories. I will add testing and better handling for this in the PR Focus app code in the future, but for the moment, this details the required permissions for each type of token.

This GitHub article[ X-Accepted-GitHub-Permissions header for fine-grained permission actors](https://github.blog/changelog/2023-08-10-x-accepted-github-permissions-header-for-fine-grained-permission-actors/) has details for getting the required permissions for various endpoints.